### PR TITLE
type hints for `connect`, at least in docstring (for beginners)

### DIFF
--- a/possibledb-client/src/possibledb_client/core.clj
+++ b/possibledb-client/src/possibledb_client/core.clj
@@ -9,7 +9,7 @@
   (java.net.Socket. host port))
 
 (defn connect!
-  "Connect to a PossibleDB server"
+  "Connect to a PossibleDB server (String host Integer port)"
   [host port]
   (reset! reload-conn [host port])
   (reset! connection


### PR DESCRIPTION
There might be a reason why the fn `connect` doesn't have type hints but still in the doc string we might want to specify that we want a String for `host` and an Integer for `port`. This might help a beginner like me :)
